### PR TITLE
cal コマンドの Ruby での実装

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -16,8 +16,8 @@ opt.on('-y VAL') { |v| params[:year] = v.to_i }
 opt.parse!(ARGV)
 
 # 引数が渡されなかった際に当年当月を格納する
-params[:month] = Date.today.month if params[:month].nil?
-params[:year] = Date.today.year if params[:year].nil?
+params[:month] ||= Date.today.month
+params[:year] ||= Date.today.year
 
 def header(month, year)
   res = "#{month}月 #{year}".center((DAY_WIDTH + 1) * 7)

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -21,8 +21,7 @@ params[:year] = Date.today.year if params[:year].nil?
 
 def header(month, year)
   res = "#{month}月 #{year}".center((DAY_WIDTH + 1) * 7)
-  res += "\n"
-  res
+  res << "\n"
 end
 
 # カレンダーのコンテンツ領域を作成する

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'date'
 require 'optparse'
 
 opt = OptionParser.new
@@ -9,3 +10,7 @@ params = {}
 opt.on('-m VAL') { |v| params[:month] = v }
 opt.on('-y VAL') { |v| params[:year] = v }
 opt.parse!(ARGV)
+
+# 引数が渡されなかった際に当年当月を格納する
+params[:month] = Date.today.month if params[:month].nil?
+params[:year] = Date.today.year if params[:year].nil?

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,2 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
+require 'optparse'
+
+opt = OptionParser.new
+params = {}
+
+opt.on('-m VAL') { |v| params[:month] = v }
+opt.on('-y VAL') { |v| params[:year] = v }
+opt.parse!(ARGV)

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'colorize'
 require 'date'
 require 'optparse'
 
@@ -31,7 +32,8 @@ def cal_content(month, year)
 
   res = ' ' * first_date.wday * (DAY_WIDTH + 1)
   (first_date..last_date).each do |date|
-    res += date.day.to_s.rjust(DAY_WIDTH)
+    tmp = date.day.to_s.rjust(DAY_WIDTH)
+    res += date == Date.today ? tmp.colorize(color: :black, background: :white) : tmp
     res += date.saturday? ? "\n" : ' '
   end
 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -18,7 +18,7 @@ opt.parse!(ARGV)
 params[:month] = Date.today.month if params[:month].nil?
 params[:year] = Date.today.year if params[:year].nil?
 
-def title(month, year)
+def header(month, year)
   "      #{month}月 #{year}\n"
 end
 
@@ -37,7 +37,7 @@ def cal_content(month, year)
 end
 
 def render(month, year)
-  result = title(month, year) + DOW + cal_content(month, year)
+  result = header(month, year) + DOW + cal_content(month, year)
   puts result
 end
 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -19,7 +19,9 @@ params[:month] = Date.today.month if params[:month].nil?
 params[:year] = Date.today.year if params[:year].nil?
 
 def header(month, year)
-  "      #{month}月 #{year}\n"
+  res = "#{month}月 #{year}".center((DAY_WIDTH + 1) * 7)
+  res += "\n"
+  res
 end
 
 # カレンダーのコンテンツ領域を作成する

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'date'
 require 'optparse'
 
-DOW = '日 月 火 水 木 金 土'.freeze
+DOW = "日 月 火 水 木 金 土\n"
 opt = OptionParser.new
 params = {}
 
@@ -20,9 +21,7 @@ def title(month, year)
 end
 
 def render(month, year)
-  result = ''
-  result << title(month, year)
-  result << DOW
+  result = title(month, year) + DOW
   puts result
 end
 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 require 'date'
 require 'optparse'
 
+DOW = '日 月 火 水 木 金 土'.freeze
 opt = OptionParser.new
 params = {}
 
@@ -14,3 +14,16 @@ opt.parse!(ARGV)
 # 引数が渡されなかった際に当年当月を格納する
 params[:month] = Date.today.month if params[:month].nil?
 params[:year] = Date.today.year if params[:year].nil?
+
+def title(month, year)
+  "      #{month}月 #{year}\n"
+end
+
+def render(month, year)
+  result = ''
+  result << title(month, year)
+  result << DOW
+  puts result
+end
+
+render(params[:month], params[:year])

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -4,12 +4,14 @@
 require 'date'
 require 'optparse'
 
+DAY_WIDTH = 2
 DOW = "日 月 火 水 木 金 土\n"
+
 opt = OptionParser.new
 params = {}
 
-opt.on('-m VAL') { |v| params[:month] = v }
-opt.on('-y VAL') { |v| params[:year] = v }
+opt.on('-m VAL') { |v| params[:month] = v.to_i }
+opt.on('-y VAL') { |v| params[:year] = v.to_i }
 opt.parse!(ARGV)
 
 # 引数が渡されなかった際に当年当月を格納する
@@ -20,8 +22,22 @@ def title(month, year)
   "      #{month}月 #{year}\n"
 end
 
+# カレンダーのコンテンツ領域を作成する
+def cal_content(month, year)
+  first_date = Date.new(year, month, 1)
+  last_date = Date.new(year, month, -1)
+
+  res = ' ' * first_date.wday * (DAY_WIDTH + 1)
+  (first_date..last_date).each do |date|
+    res += date.day.to_s.rjust(DAY_WIDTH)
+    res += date.saturday? ? "\n" : ' '
+  end
+
+  res
+end
+
 def render(month, year)
-  result = title(month, year) + DOW
+  result = title(month, year) + DOW + cal_content(month, year)
   puts result
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'colorize'
+
 # For plain Ruby scripts
 group :development do
   gem 'rubocop-fjord', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+# For plain Ruby scripts
+group :development do
+  gem 'rubocop-fjord', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    colorize (0.8.1)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -32,7 +33,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  colorize
   rubocop-fjord
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.18.4)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.8.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.9.0)
+      parser (>= 3.0.1.1)
+    rubocop-fjord (0.1.5)
+      rubocop (>= 1.0)
+      rubocop-performance
+    rubocop-performance (1.11.4)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop-fjord
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
[カレンダーのプログラム(ruby)](https://bootcamp.fjord.jp/practices/194) を作成しました。

お手数ですが、レビュー宜しくお願いいたします。

## 対応していないこと

- どのような引数が与えられようが、`cal` コマンドと同じ表示結果になる

## 実行方法

```
$ bundle install  # colorize gem を導入しているため
$ ./02.calendar/cal.rb
```

## 実行結果

![image](https://user-images.githubusercontent.com/24557514/128661153-59557b45-0d18-40d2-be7b-81e688c58166.png)

## 感想

- カレンダーのコンテンツ領域を表示させる際に、リストを使おうと思いましたが、シンプルに文字列だけで対応してみました
- 文字列の結合を `+` で行っているので、膨大な量になった際のパフォーマンスが若干気がかりです
  - 今回のケースでは問題になることはないだろうと考えて、`+` のままにしています
- 当日が含まれていた場合の色反転を `colorize` gem で対応していますが、標準ライブラリ以外を利用したのは微妙だったかも？と思えて来ました…
- コマンドラインを処理するコードとカレンダーを作成するコードを別ファイルにしようかと思いましたが、対したコード量にならなかったので一つのファイルで対応しました
