### PR TITLE
wc コマンドを作る

### DIFF
--- a/06.wc/lib/main.rb
+++ b/06.wc/lib/main.rb
@@ -11,12 +11,12 @@ def main
   opt.parse!(ARGV)
 
   # 標準入力にも引数にもデータがなかった場合、無限に入力を待ち続けてしまう
-  if ARGV.empty?
-    contents = readlines
-    word_counts = [WC.create_word_count(contents)]
-  else
-    word_counts = WC.create_word_count_from_path(ARGV)
-  end
+  word_counts = if ARGV.empty?
+                  contents = reallines
+                  [WC.create_word_count(contents)]
+                else
+                  WC.create_word_count_from_path(ARGV)
+                end
 
   format = WC::Format.new(word_counts, **params)
   puts format.render

--- a/06.wc/lib/main.rb
+++ b/06.wc/lib/main.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require './06.wc/lib/wc'
+
+def main
+  opt = OptionParser.new
+  params = {}
+  opt.on('-l') { |v| params[:lines] = v }
+  opt.parse!(ARGV)
+
+  # 標準入力にも引数にもデータがなかった場合、無限に入力を待ち続けてしまう
+  if ARGV.empty?
+    contents = readlines
+    word_counts = [WC.create_word_count(contents)]
+  else
+    word_counts = WC.create_word_count_from_path(ARGV)
+  end
+
+  format = WC::Format.new(word_counts, **params)
+  puts format.render
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/06.wc/lib/main.rb
+++ b/06.wc/lib/main.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require './06.wc/lib/wc'
+require_relative 'wc'
 
 def main
   opt = OptionParser.new

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -12,7 +12,7 @@ module WC
   class WordCount
     attr_reader :lines, :words, :bytes, :name
 
-    def initialize(contents, path = '')
+    def initialize(contents, path)
       @lines = contents.size
       @words = contents.join.split(/\s+/).count { |s| !s.empty? }
       @bytes = contents.join.bytesize

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -26,9 +26,9 @@ module WC
     attr_reader :lines, :words, :bytes, :name
 
     def initialize(word_counts)
-      @lines = word_counts.inject(0) { |result, word_count| result + word_count.lines }
-      @words = word_counts.inject(0) { |result, word_count| result + word_count.words }
-      @bytes = word_counts.inject(0) { |result, word_count| result + word_count.bytes }
+      @lines = word_counts.each.sum(&:lines)
+      @words = word_counts.each.sum(&:words)
+      @bytes = word_counts.each.sum(&:bytes)
       @name = NAME
     end
   end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -38,19 +38,31 @@ module WC
       @word_counts = word_counts
       @word_counts << TotalWordCount.new(@word_counts) if @word_counts.size >= 2
       @lines = lines
+      @max_num_legth = calc_max_num_of_digits
     end
 
     def render
-      render_default
+      @lines ? render_lines : render_default
     end
 
     private
 
     def render_default
-      @max_num_legth = calc_max_num_of_digits
       result = []
       @word_counts.each do |w|
         result << "#{format_number(w.lines)} #{format_number(w.words)} #{format_number(w.bytes)} #{w.name}"
+      end
+      result.join("\n")
+    end
+
+    def render_lines
+      result = []
+      @word_counts.each do |w|
+        result << if @word_counts.size == 1
+                    "#{w.lines} #{w.name}"
+                  else
+                    "#{format_number(w.lines)} #{w.name}"
+                  end
       end
       result.join("\n")
     end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -4,4 +4,15 @@ module WC
   def self.read_files(paths)
     paths.map { |path| File.readlines(path) }
   end
+
+  class WordCount
+    attr_reader :lines, :words, :bytes, :name
+
+    def initialize(contents, path = '')
+      @lines = contents.size
+      @words = contents.join.split(/\s+/).count { |s| !s.empty? }
+      @bytes = contents.join.bytesize
+      @name = path
+    end
+  end
 end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -26,9 +26,9 @@ module WC
     attr_reader :lines, :words, :bytes, :name
 
     def initialize(word_counts)
-      @lines = word_counts.each.sum(&:lines)
-      @words = word_counts.each.sum(&:words)
-      @bytes = word_counts.each.sum(&:bytes)
+      @lines = word_counts.sum(&:lines)
+      @words = word_counts.sum(&:words)
+      @bytes = word_counts.sum(&:bytes)
       @name = NAME
     end
   end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WC
+  def self.read_files(paths)
+    paths.map { |path| File.readlines(path) }
+  end
+end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -48,23 +48,11 @@ module WC
     private
 
     def render_default
-      result = []
-      @word_counts.each do |w|
-        result << "#{format_number(w.lines)} #{format_number(w.words)} #{format_number(w.bytes)} #{w.name}"
-      end
-      result.join("\n")
+      @word_counts.map { |w| "#{format_number(w.lines)} #{format_number(w.words)} #{format_number(w.bytes)} #{w.name}" }.join("\n")
     end
 
     def render_lines
-      result = []
-      @word_counts.each do |w|
-        result << if @word_counts.size == 1
-                    "#{w.lines} #{w.name}"
-                  else
-                    "#{format_number(w.lines)} #{w.name}"
-                  end
-      end
-      result.join("\n")
+      @word_counts.map { |w| @word_counts.size == 1 ? "#{w.lines} #{w.name}" : "#{format_number(w.lines)} #{w.name}" }.join("\n")
     end
 
     def calc_max_num_of_digits

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module WC
-  def self.read_files(paths)
-    paths.map { |path| File.readlines(path) }
+  def self.create_word_count_from_path(paths)
+    paths.map { |path| create_word_count(File.readlines(path), path) }
+  end
+
+  def self.create_word_count(contents, path = '')
+    WordCount.new(contents, path)
   end
 
   class WordCount

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -32,4 +32,41 @@ module WC
       @name = NAME
     end
   end
+
+  class Format
+    def initialize(word_counts, lines: false)
+      @word_counts = word_counts
+      @word_counts << TotalWordCount.new(@word_counts) if @word_counts.size >= 2
+      @lines = lines
+    end
+
+    def render
+      render_default
+    end
+
+    private
+
+    def render_default
+      @max_num_legth = calc_max_num_of_digits
+      result = []
+      @word_counts.each do |w|
+        result << "#{format_number(w.lines)} #{format_number(w.words)} #{format_number(w.bytes)} #{w.name}"
+      end
+      result.join("\n")
+    end
+
+    def calc_max_num_of_digits
+      digits = []
+      @word_counts.each do |w|
+        digits << w.lines
+        digits << w.words
+        digits << w.bytes
+      end
+      digits.map { |d| d.to_s.length }.max
+    end
+
+    def format_number(num)
+      num.to_s.rjust(@max_num_legth)
+    end
+  end
 end

--- a/06.wc/lib/wc.rb
+++ b/06.wc/lib/wc.rb
@@ -19,4 +19,17 @@ module WC
       @name = path
     end
   end
+
+  class TotalWordCount
+    NAME = 'total'
+
+    attr_reader :lines, :words, :bytes, :name
+
+    def initialize(word_counts)
+      @lines = word_counts.inject(0) { |result, word_count| result + word_count.lines }
+      @words = word_counts.inject(0) { |result, word_count| result + word_count.words }
+      @bytes = word_counts.inject(0) { |result, word_count| result + word_count.bytes }
+      @name = NAME
+    end
+  end
 end

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -7,7 +7,7 @@ class WSTest < Minitest::Test
   def test_read_files
     expected = [
       ["Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n"],
-      ["Almost before we knew it, we had left the ground.\n"]
+      ["Almost before we knew it, we had left the ground.\n", "\n", "Almost before we knew it, we had left the ground.\n", "\n", "\n"]
     ]
     actual = WC.read_files(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
     assert_equal expected, actual

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
-require './06.wc/lib/wc'
+require_relative '../lib/wc'
 
 class WSTest < Minitest::Test
   def test_create_word_count_from_path

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -10,4 +10,28 @@ class WSTest < Minitest::Test
       assert_instance_of(WC::WordCount, w)
     end
   end
+
+  def test_single_file_format
+    wc = WC.create_word_count_from_path(%w[06.wc/testdata/foo.txt])
+    format = WC::Format.new(wc)
+    actual = format.render
+
+    expected = <<-TEXT.chomp
+  4  20 108 06.wc/testdata/foo.txt
+    TEXT
+    assert_equal expected, actual
+  end
+
+  def test_multi_files_format
+    wc = WC.create_word_count_from_path(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
+    format = WC::Format.new(wc)
+    actual = format.render
+
+    expected = <<-TEXT.chomp
+  4  20 108 06.wc/testdata/foo.txt
+  5  20 103 06.wc/testdata/bar.md
+  9  40 211 total
+    TEXT
+    assert_equal expected, actual
+  end
 end

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require './06.wc/lib/wc'
+
+class WSTest < Minitest::Test
+  def test_read_files
+    expected = [
+      ["Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n"],
+      ["Almost before we knew it, we had left the ground.\n"]
+    ]
+    actual = WC.read_files(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
+    assert_equal expected, actual
+  end
+end

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -4,12 +4,10 @@ require 'minitest/autorun'
 require './06.wc/lib/wc'
 
 class WSTest < Minitest::Test
-  def test_read_files
-    expected = [
-      ["Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n", "Lorem ipsum dolor sit amet\n"],
-      ["Almost before we knew it, we had left the ground.\n", "\n", "Almost before we knew it, we had left the ground.\n", "\n", "\n"]
-    ]
-    actual = WC.read_files(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
-    assert_equal expected, actual
+  def test_create_word_count_from_path
+    word_counts = WC.create_word_count_from_path(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
+    word_counts.each do |w|
+      assert_instance_of(WC::WordCount, w)
+    end
   end
 end

--- a/06.wc/test/wc_test.rb
+++ b/06.wc/test/wc_test.rb
@@ -34,4 +34,28 @@ class WSTest < Minitest::Test
     TEXT
     assert_equal expected, actual
   end
+
+  def test_single_file_line_option_format
+    wc = WC.create_word_count_from_path(%w[06.wc/testdata/foo.txt])
+    format = WC::Format.new(wc, lines: true)
+    actual = format.render
+
+    expected = <<~TEXT.chomp
+      4 06.wc/testdata/foo.txt
+    TEXT
+    assert_equal expected, actual
+  end
+
+  def test_multi_files_line_option_format
+    wc = WC.create_word_count_from_path(%w[06.wc/testdata/foo.txt 06.wc/testdata/bar.md])
+    format = WC::Format.new(wc, lines: true)
+    actual = format.render
+
+    expected = <<-TEXT.chomp
+  4 06.wc/testdata/foo.txt
+  5 06.wc/testdata/bar.md
+  9 total
+    TEXT
+    assert_equal expected, actual
+  end
 end

--- a/06.wc/testdata/bar.md
+++ b/06.wc/testdata/bar.md
@@ -1,0 +1,1 @@
+Almost before we knew it, we had left the ground.

--- a/06.wc/testdata/bar.md
+++ b/06.wc/testdata/bar.md
@@ -1,1 +1,5 @@
 Almost before we knew it, we had left the ground.
+
+Almost before we knew it, we had left the ground.
+
+

--- a/06.wc/testdata/foo.txt
+++ b/06.wc/testdata/foo.txt
@@ -1,0 +1,4 @@
+Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet
+Lorem ipsum dolor sit amet


### PR DESCRIPTION
[wc コマンドを作る](https://bootcamp.fjord.jp/practices/161)を対応しました。

お手数ですが、こちらレビューをお願いいたします。

## 実行結果

### 自作 `wc` コマンド

![image](https://user-images.githubusercontent.com/24557514/129859524-67e8c568-a058-40ed-81dc-05aa748c0a4d.png)

### `wc` コマンド

![image](https://user-images.githubusercontent.com/24557514/129859597-eb721715-b4da-465c-a47c-91959d654102.png)

## `rubocop-fjord` の実行結果

![image](https://user-images.githubusercontent.com/24557514/129859442-a7d9d2cd-1ed0-4cf5-ac6f-bc88f68a7b68.png)

## 補足

- 日本語対応はしていません
- 標準入力から文字列を受け取った場合の空白の出力ロジックが不明だったため、揃えていません

### テキスト版のコマンド

```shell
$ ./06.wc/lib/main.rb 06.wc/testdata/foo.txt
$ ./06.wc/lib/main.rb 06.wc/testdata/foo.txt 06.wc/testdata/bar.md
$ ./06.wc/lib/main.rb -l 06.wc/testdata/foo.txt 06.wc/testdata/bar.md
$ ls | ./06.wc/lib/main.rb
$ ls | ./06.wc/lib/main.rb -l

$ wc 06.wc/testdata/foo.txt
$ wc 06.wc/testdata/foo.txt 06.wc/testdata/bar.md
$ wc -l 06.wc/testdata/foo.txt 06.wc/testdata/bar.md
$ ls | wc
$ ls | wc -l
```

## 感想

- `WordCount`, `TotalWordCount` class が似通っているので、共通化できないか考えましたが一旦断念…
